### PR TITLE
Rename event names to prevent risk of confusion

### DIFF
--- a/contracts/FxRates.sol
+++ b/contracts/FxRates.sol
@@ -23,7 +23,7 @@ contract FxRates is Ownable {
      * @param timestamp human readable timestamp of the earliest validity time
      * @param rate a string containing the rate value
      */
-    event RateUpdate(string symbol, uint256 updateNumber, string timestamp, string rate);
+    event LogRateUpdate(string symbol, uint256 updateNumber, string timestamp, string rate);
 
     uint256 public numberBtcUpdates = 0;
 
@@ -44,7 +44,7 @@ contract FxRates is Ownable {
             rate: _rate,
             timestamp: _timestamp
         });
-        RateUpdate("ETH", numberEthUpdates, _timestamp, _rate);
+        LogRateUpdate("ETH", numberEthUpdates, _timestamp, _rate);
     }
 
     /**
@@ -58,7 +58,7 @@ contract FxRates is Ownable {
             rate: _rate,
             timestamp: _timestamp
         });
-        RateUpdate("BTC", numberBtcUpdates, _timestamp, _rate);
+        LogRateUpdate("BTC", numberBtcUpdates, _timestamp, _rate);
     }
 
     /**

--- a/contracts/SvdMainSale.sol
+++ b/contracts/SvdMainSale.sol
@@ -37,7 +37,7 @@ contract SvdMainSale is Pausable {
      * @param beneficiary who got the tokens
      * @param value weis paid for purchase
      */
-    event Investment(address indexed purchaser,
+    event LogInvestment(address indexed purchaser,
         address indexed beneficiary,
         uint256 value);
 
@@ -106,7 +106,7 @@ contract SvdMainSale is Pausable {
         // track how much was transfered by the specific investor
         investments[beneficiary] = investments[beneficiary].add(weiAmount);
 
-        Investment(msg.sender, beneficiary, weiAmount);
+        LogInvestment(msg.sender, beneficiary, weiAmount);
 
         forwardFunds();
     }

--- a/contracts/SvdPreSale.sol
+++ b/contracts/SvdPreSale.sol
@@ -45,7 +45,7 @@ contract SvdPreSale is Pausable {
      * @param beneficiary who got the tokens
      * @param value weis paid for purchase
      */
-    event Investment(address indexed purchaser,
+    event LogInvestment(address indexed purchaser,
         address indexed beneficiary,
         uint256 value);
 
@@ -54,7 +54,7 @@ contract SvdPreSale is Pausable {
      * @param investor the address that was whitelisted
      * @param status the status value, true if it is whitelisted, false otherwise
      */
-    event Whitelisted(address investor, bool status);
+    event LogWhitelisted(address investor, bool status);
 
     /**
      * @dev Constructor
@@ -117,7 +117,7 @@ contract SvdPreSale is Pausable {
         // track how much was transfered by the specific investor
         investments[beneficiary] = investments[beneficiary].add(weiAmount);
 
-        Investment(msg.sender, beneficiary, weiAmount);
+        LogInvestment(msg.sender, beneficiary, weiAmount);
 
         forwardFunds();
     }
@@ -146,7 +146,7 @@ contract SvdPreSale is Pausable {
     function setInvestorWhitelist(address addr, bool status) public {
         require(msg.sender == whitelister);
         investorWhitelist[addr] = status;
-        Whitelisted(addr, status);
+        LogWhitelisted(addr, status);
     }
 
     // send ether (wei) to the fund collection wallet

--- a/contracts/SvdToken.sol
+++ b/contracts/SvdToken.sol
@@ -16,7 +16,7 @@ import "../node_modules/zeppelin-solidity/contracts/math/SafeMath.sol";
 contract SvdToken is MintableToken, Pausable {
     using SafeMath for uint256;
 
-    event Burn(address indexed burner, uint256 value);
+    event LogBurn(address indexed burner, uint256 value);
 
     string public constant NAME = "savedroid";
     string public constant SYMBOL = "SVD";
@@ -130,7 +130,7 @@ contract SvdToken is MintableToken, Pausable {
         address burner = msg.sender;
         balances[burner] = balances[burner].sub(_value);
         totalSupply = totalSupply.sub(_value);
-        Burn(burner, _value);
+        LogBurn(burner, _value);
     }
 
 


### PR DESCRIPTION
Smart contracts in the past had introduced severe bugs due to the confusion between a function and an event name.
A good practice is to explicitly prepend  Log for each event. More info [here.](https://consensys.github.io/smart-contract-best-practices/recommendations/#differentiate-functions-and-events)