### PR TITLE
package.json name 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "Savedroid ICO smart contracts",
+  "name": "savedroid",
   "version": "1.0.0",
-  "description": "The smart contracts for Savedroid's ICO http://ico.savedroid.com",
+  "description":
+    "The smart contracts for Savedroid's ICO http://ico.savedroid.com",
   "main": "truffle.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
By design, name in `package.json` cant start with a capital letter or whitespaces. Due to this fact `npm install` does not work.